### PR TITLE
Add multiple favicons support

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -8,10 +8,9 @@
     <meta itemprop="name" content="{{ .Title }}" />
     <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}" />
     <meta name="theme-color" content="#f38e50">
+    <meta name="msapplication-TileColor" content="#f38e50">
 
-    {{ if fileExists "static/assets/favicon.png" -}}
-    <link href='{{ "assets/favicon.png" | relURL }}' rel="icon">
-    {{- end }}
+    {{ partial "favicons.html" . }}
 
     {{- $style := resources.Get "sass/style.scss" | toCSS | minify | fingerprint }}
     <link href='{{ $style.Permalink }}' rel='stylesheet' type="text/css" />

--- a/layouts/partials/favicons.html
+++ b/layouts/partials/favicons.html
@@ -13,6 +13,9 @@
 {{- if fileExists "static/assets/favicon-64x64.png" }}
     <link rel="icon" type="image/png" href='{{ "assets/favicon-64x64.png" | relURL }}' sizes="64x64">
 {{- end }}
+{{- if fileExists "static/assets/favicon-96x96.png" }}
+    <link rel="icon" type="image/png" href='{{ "assets/favicon-96x96.png" | relURL }}' sizes="96x96">
+{{- end }}
 {{- if fileExists "static/assets/apple-touch-icon.png" }}
     <link rel="apple-touch-icon" href='{{ "assets/apple-touch-icon.png" | relURL }}' sizes="180x180">
 {{- end }}

--- a/layouts/partials/favicons.html
+++ b/layouts/partials/favicons.html
@@ -1,0 +1,18 @@
+{{- if fileExists "static/assets/favicon.png" -}}
+    <link rel="icon" type="image/png" href='{{ "assets/favicon.png" | relURL }}'>
+{{- end }}
+{{- if fileExists "static/assets/favicon-16x16.png" }}
+    <link rel="icon" type="image/png" href='{{ "assets/favicon-16x16.png" | relURL }}' sizes="16x16">
+{{- end }}
+{{- if fileExists "static/assets/favicon-32x32.png" }}
+    <link rel="icon" type="image/png" href='{{ "assets/favicon-32x32.png" | relURL }}' sizes="32x32">
+{{- end }}
+{{- if fileExists "static/assets/favicon-48x48.png" }}
+    <link rel="icon" type="image/png" href='{{ "assets/favicon-48x48.png" | relURL }}' sizes="48x48">
+{{- end }}
+{{- if fileExists "static/assets/favicon-64x64.png" }}
+    <link rel="icon" type="image/png" href='{{ "assets/favicon-64x64.png" | relURL }}' sizes="64x64">
+{{- end }}
+{{- if fileExists "static/assets/apple-touch-icon.png" }}
+    <link rel="apple-touch-icon" href='{{ "assets/apple-touch-icon.png" | relURL }}' sizes="180x180">
+{{- end }}


### PR DESCRIPTION
This more or less fix #1, it does not support .ico files, Android natively (I believe it can use Apple's stuff) and Windows Metro stuff

- [x] Add multiple favicon support 
- [ ] Update README